### PR TITLE
OS X keybindings with alt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Provides ability to jump into camelCase and UPPER_CASE words using:
 * `ctrl-delete` - to delete next sub-word
 * `ctrl-backspace` - to delete previous sub-word
 
+Replace `ctrl` with `alt` if you are on OS X - just as native bindings.
+
 This is an enhanced version of ajile's word-jumper package (https://github.com/ajile/word-jumper). 
 
 In action:

--- a/keymaps/word-jumper-deluxe.cson
+++ b/keymaps/word-jumper-deluxe.cson
@@ -1,9 +1,21 @@
-'atom-workspace atom-text-editor':
-  'ctrl-right': 'word-jumper-deluxe:move-right'
-  'ctrl-left': 'word-jumper-deluxe:move-left'
+'.platform-darwin':
+  'atom-workspace atom-text-editor':
+    'alt-right': 'word-jumper-deluxe:move-right'
+    'alt-left': 'word-jumper-deluxe:move-left'
 
-  'ctrl-shift-right': 'word-jumper-deluxe:select-right'
-  'ctrl-shift-left': 'word-jumper-deluxe:select-left'
+    'alt-shift-right': 'word-jumper-deluxe:select-right'
+    'alt-shift-left': 'word-jumper-deluxe:select-left'
 
-  'ctrl-delete': 'word-jumper-deluxe:remove-right'
-  'ctrl-backspace': 'word-jumper-deluxe:remove-left'
+    'alt-delete': 'word-jumper-deluxe:remove-right'
+    'alt-backspace': 'word-jumper-deluxe:remove-left'
+
+'.platform-win32, .platform-linux':
+  'atom-workspace atom-text-editor':
+    'ctrl-right': 'word-jumper-deluxe:move-right'
+    'ctrl-left': 'word-jumper-deluxe:move-left'
+
+    'ctrl-shift-right': 'word-jumper-deluxe:select-right'
+    'ctrl-shift-left': 'word-jumper-deluxe:select-left'
+
+    'ctrl-delete': 'word-jumper-deluxe:remove-right'
+    'ctrl-backspace': 'word-jumper-deluxe:remove-left'


### PR DESCRIPTION
So they match [the native bindings](https://github.com/atom/atom/blob/4988f6b/keymaps/darwin.cson#L106-L111) - CTRL + Arrow switches desktops
